### PR TITLE
Add Google Gemini provider adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It supports:
 - **Self-Consistency**: variance across `n` samples.
 - **JSON/CSV outputs** and **HTML report**.
 
-> Providers supported: OpenAI (text + embeddings), generic HTTP (bring your own), local function hook.
+> Providers supported: OpenAI, Google Gemini, generic HTTP (bring your own), local function hook.
 > Set keys via env vars; the CLI never requires Hugging Face.
 
 ## Quick start
@@ -21,6 +21,30 @@ pip install -r requirements.txt
 # Evaluate example dataset with OpenAI (set OPENAI_API_KEY first)
 python -m llmeval.runners.eval --config config.yaml
 ```
+
+### Using Google Gemini
+
+1. Create an API key from [Google AI Studio](https://aistudio.google.com/).
+2. Export it as `GEMINI_API_KEY` (or `GOOGLE_API_KEY`).
+3. Switch the config to use the Gemini adapter:
+
+```yaml
+provider: gemini
+gemini:
+  model: gemini-2.5-flash
+  embedding_model: text-embedding-004
+```
+
+You can override `base_url`, `generation_config`, or `safety_settings` in
+`config.yaml` if you are routing requests through a proxy or need custom
+Gemini safety parameters.
+
+### Open-source or self-hosted models
+
+If you are running an open-source model (e.g. via vLLM, TGI, Ollama) you can
+either expose an HTTP endpoint and use the `generic` provider, or plug in a
+Python callable through the `local` provider. Both approaches let you reuse the
+same evaluation pipeline without depending on proprietary APIs.
 
 ## Data format
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,11 +1,18 @@
 # Evaluation config
 dataset_path: data/examples/qa.jsonl
 generations_path: data/examples/generations.jsonl
-provider: openai   # one of: openai, generic, local
+provider: openai   # one of: openai, gemini, generic, local
 openai:
   model: gpt-4o-mini
   embedding_model: text-embedding-3-large
   moderation: true
+gemini:
+  model: gemini-2.5-flash
+  embedding_model: text-embedding-004
+  # Optional overrides for generation/embedding endpoints
+  base_url: https://generativelanguage.googleapis.com/v1beta
+  generation_config: {}
+  safety_settings: []
 generic:
   # POST http provider for a judge endpoint and embeddings endpoint (optional)
   judge_url: ""

--- a/src/llmeval/providers/__init__.py
+++ b/src/llmeval/providers/__init__.py
@@ -1,10 +1,13 @@
 from .openai_provider import OpenAIProvider
 from .generic_http_provider import GenericHTTPProvider
 from .local_provider import LocalProvider
+from .gemini_provider import GeminiProvider
 
 def get_provider(name: str, **kwargs):
     if name == 'openai':
         return OpenAIProvider(**kwargs.get('openai', {}))
+    if name == 'gemini':
+        return GeminiProvider(**kwargs.get('gemini', {}))
     if name == 'generic':
         return GenericHTTPProvider(**kwargs.get('generic', {}))
     if name == 'local':

--- a/src/llmeval/providers/gemini_provider.py
+++ b/src/llmeval/providers/gemini_provider.py
@@ -1,0 +1,117 @@
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import requests
+
+
+class GeminiProvider:
+    """Provider wrapper around Google's Gemini API.
+
+    The provider mirrors the :class:`OpenAIProvider` interface, supporting
+    judge, embed and (noop) moderation helpers so it can drop in wherever the
+    OpenAI adapter is currently used.
+    """
+
+    def __init__(
+        self,
+        model: str = "gemini-2.5-flash",
+        embedding_model: str = "text-embedding-004",
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        generation_config: Optional[Dict[str, Any]] = None,
+        safety_settings: Optional[List[Dict[str, Any]]] = None,
+        timeout: int = 120,
+    ) -> None:
+        self.model = model
+        self.embedding_model = embedding_model
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY") or os.getenv("GOOGLE_API_KEY", "")
+        self.base_url = (base_url or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
+        self.generation_config = generation_config or {}
+        self.safety_settings = safety_settings or []
+        self.timeout = timeout
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _headers(self) -> Dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["x-goog-api-key"] = self.api_key
+        return headers
+
+    def _params(self) -> Optional[Dict[str, str]]:
+        # The API accepts both header and query params for the key. To avoid
+        # leaking keys in URLs we prefer a header, but keep params for
+        # compatibility with self-hosted proxies that expect it there.
+        if not self.api_key:
+            return None
+        return {"key": self.api_key}
+
+    def _model_path(self, name: str) -> str:
+        return name if name.startswith("models/") else f"models/{name}"
+
+    # ------------------------------------------------------------------
+    # Public interface
+    def judge(self, prompt: str, rubric_json: Dict[str, Any]) -> Dict[str, Any]:
+        """Call Gemini to evaluate a prompt using the supplied rubric."""
+
+        payload: Dict[str, Any] = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": prompt}],
+                }
+            ],
+            "generationConfig": {"responseMimeType": "application/json"},
+        }
+        if rubric_json.get("system"):
+            payload["systemInstruction"] = {
+                "parts": [{"text": rubric_json["system"]}],
+            }
+        if self.generation_config:
+            payload["generationConfig"].update(self.generation_config)
+        if self.safety_settings:
+            payload["safetySettings"] = self.safety_settings
+
+        url = f"{self.base_url}/models/{self.model}:generateContent"
+        response = requests.post(
+            url,
+            headers=self._headers(),
+            params=self._params(),
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        try:
+            text = data["candidates"][0]["content"]["parts"][0]["text"]
+        except (KeyError, IndexError) as exc:
+            raise RuntimeError(f"Unexpected Gemini response: {data}") from exc
+        return json.loads(text)
+
+    def embed(self, texts: List[str]) -> List[List[float]]:
+        if not texts:
+            return []
+        url = f"{self.base_url}/models/{self.embedding_model}:batchEmbedContents"
+        payload = {
+            "model": self._model_path(self.embedding_model),
+            "requests": [
+                {"content": {"parts": [{"text": text}]}} for text in texts
+            ],
+        }
+        response = requests.post(
+            url,
+            headers=self._headers(),
+            params=self._params(),
+            json=payload,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        data = response.json()
+        embeddings = data.get("embeddings", [])
+        return [emb.get("values", []) for emb in embeddings]
+
+    def moderate(self, text: str) -> Dict[str, Any]:
+        # Gemini safety checks are handled via ``safetySettings`` passed during
+        # ``judge`` calls, so we no-op here to mirror the GenericProvider.
+        return {}


### PR DESCRIPTION
## Summary
- add a GeminiProvider that maps the framework's judge/embed calls onto the Google Generative Language API
- expose provider selection/configuration via config.yaml and update documentation with Gemini usage and open-source guidance

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d2ca8832a08333ae1381ee6cd37ddd