### PR TITLE
Add packaging metadata and editable install guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ Open a terminal or command prompt in the project folder and run:
 python -m venv .venv
 source .venv/bin/activate  # Windows PowerShell: .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
+pip install -e .
 ```
 
 > **Tip:** Each time you come back to the project, run `source .venv/bin/activate`
 > (or the Windows command above) so that Python uses the right dependencies.
+
+The editable install (`pip install -e .`) puts the `llmeval` package on your
+Python path so that the runner command in the next section can import it.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llmeval"
+version = "0.1.0"
+description = "LLM Evaluation Framework"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {text = "MIT"}
+authors = [{name = "LLM Evaluation Framework"}]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+]
+dependencies = []
+
+[project.urls]
+Homepage = "https://example.com/llm-eval-framework"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["llmeval*"]

--- a/src/llmeval/__init__.py
+++ b/src/llmeval/__init__.py
@@ -1,0 +1,3 @@
+"""LLM Evaluation Framework package."""
+
+__all__ = []


### PR DESCRIPTION
## Summary
- configure setuptools via pyproject.toml to expose the llmeval package from src/
- add a package initializer for llmeval
- document running `pip install -e .` after creating the virtual environment so the package is importable when invoking the runner

## Testing
- `pip install -r requirements.txt` *(fails: tunnel connection failed: 403 Forbidden)*
- `pip install -e .` *(fails: tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d2d618fd188333b969a5f4153c1393