### PR TITLE
Improve config loading in eval runner

### DIFF
--- a/src/llmeval/runners/eval.py
+++ b/src/llmeval/runners/eval.py
@@ -14,7 +14,16 @@ def main():
     ap.add_argument('--config', required=True)
     args = ap.parse_args()
     import yaml
-    cfg = yaml.safe_load(open(args.config,'r'))
+    from pathlib import Path
+
+    cfg_path = Path(args.config).expanduser()
+    if not cfg_path.exists():
+        ap.error(f"Config file '{cfg_path}' not found.")
+
+    with cfg_path.open("r", encoding="utf-8") as f:
+        cfg = yaml.safe_load(f)
+    if cfg is None:
+        ap.error(f"Config file '{cfg_path}' is empty.")
     # provider
     provider = get_provider(cfg.get('provider','openai'), **cfg)
     # rubric


### PR DESCRIPTION
## Summary
- add robust config loading with pathlib to validate existence and contents before parsing

## Testing
- python -m compileall src/llmeval/runners/eval.py

------
https://chatgpt.com/codex/tasks/task_e_68d37b8ca440833394a6aaef09dd7d38