### PR TITLE
Fix module import when running via src namespace

### DIFF
--- a/src/llmeval/__init__.py
+++ b/src/llmeval/__init__.py
@@ -1,3 +1,12 @@
 """LLM Evaluation Framework package."""
 
+import sys as _sys
+
+if __name__ != "llmeval":
+    # Allow importing the package both as ``llmeval`` and ``src.llmeval``
+    # when running without installing the project. This keeps compatibility
+    # with users invoking ``python -m src.llmeval...`` by registering the
+    # package under the top-level name that the rest of the code expects.
+    _sys.modules.setdefault("llmeval", _sys.modules[__name__])
+
 __all__ = []


### PR DESCRIPTION
## Summary
- register the llmeval package under its top-level name when imported via the src namespace so internal absolute imports succeed

## Testing
- python -m src.llmeval.runners.eval --config config.yaml *(fails: ProxyError contacting api.openai.com because the environment blocks external network calls)*

------
https://chatgpt.com/codex/tasks/task_e_68d37d63c4888333a14bf747f4c1307a